### PR TITLE
support outputting cards in a directory instead of a zip archive

### DIFF
--- a/IndexableAnki.py
+++ b/IndexableAnki.py
@@ -38,22 +38,28 @@ import shutil
 parser = argparse.ArgumentParser()
 parser.add_argument("-a",
                     "--anki",
-                    help="The path to the anki folder(ex:\
+                    help="The path to the anki folder (ex: \
 /home/USER/.local/share/Anki2/)",
                     dest="anki_loc",
                     metavar="ANKI_PATH")
 parser.add_argument("-p",
                     "--profile",
-                    help="Name of the anki profile you want to make\
+                    help="Name of the anki profile you want to make \
 indexable (ex: Main)",
                     dest="profile",
                     metavar="ANKI_PROFILE")
 parser.add_argument("-o",
                     "--output_dir",
-                    help="Path to the directory where the indexable\
+                    help="Path to the directory where the indexable \
 archive will be found",
                     dest="output_dir",
                     metavar="OUT_PATH")
+parser.add_argument("-f",
+                    "--format",
+                    help="Format of the output archive. Default: zip",
+                    dest="format",
+                    choices=["zip", "directory"],
+                    default="zip")
 args = parser.parse_args().__dict__
 
 
@@ -169,13 +175,20 @@ print("Saving cards as txt...")
 for i in tqdm(db.index):
     save_card_as_file(i)
 
-print("Compressing as a zip archive...")
-Path.unlink(Path(f"{args['output_dir']}/IndexableAnki_{args['profile_escaped']}.zip"), missing_ok=True)
-os.system(f"cd /tmp/IndexableAnki && zip -9 -r {args['output_dir']}/IndexableAnki_{args['profile_escaped']}.zip .")
+if args['format'] == 'zip':
+    print("Compressing as a zip archive...")
+    destination = Path(f"{args['output_dir']}/IndexableAnki_{args['profile_escaped']}.zip")
+    Path.unlink(destination, missing_ok=True)
+    os.system(f"cd /tmp/IndexableAnki && zip -9 -r {destination} .")
+else:
+    print("Saving as a directory...")
+    destination = Path(f"{args['output_dir']}/IndexableAnki_{args['profile_escaped']}")
+    shutil.rmtree(destination, ignore_errors=True)
+    os.system(f"mv /tmp/IndexableAnki {destination}")
 
 
 print("Cleaning up...")
-shutil.rmtree("/tmp/IndexableAnki")
+shutil.rmtree("/tmp/IndexableAnki", ignore_errors=True)
 Path.unlink(Path("/tmp/anki_temporary.db"), missing_ok=True)
 
 

--- a/README.md
+++ b/README.md
@@ -15,26 +15,23 @@ Turn each card of an anki collection into txt files that can be searched using a
 * make it OS agnostic, so far it can only work on linux and possibly OSX
 
 ## Usage:
-    ` python3 ./IndexableAnki.py -a ~/.local/share/Anki2 -p Myprofile -o ~/Documents/ -t /tmp/anki.db`
+```
+python3 ./IndexableAnki.py -a ~/.local/share/Anki2 -p Myprofile -o ~/Documents/
+```
 
 ```
-usage: IndexableAnki.py [-h] [-a ANKI_PATH] [-p ANKI_PROFILE] [-o output_PATH]
-                        [-t TMP_PATH]
+usage: IndexableAnki.py [-h] [-a ANKI_PATH] [-p ANKI_PROFILE] [-o OUT_PATH] [-f {zip,directory}]
 
 optional arguments:
   -h, --help            show this help message and exit
   -a ANKI_PATH, --anki ANKI_PATH
-                        The path to the anki folder(ex:
-                        /home/USER/.local/share/Anki2/)
+                        The path to the anki folder (ex: /home/USER/.local/share/Anki2/)
   -p ANKI_PROFILE, --profile ANKI_PROFILE
-                        Name of the anki profile you want to make indexable
-                        (ex: Main)
-  -o output_PATH, --output output_PATH
-                        Path to the directory that will contain the indexable
-                        anki
-  -t TMP_PATH, --temp-path TMP_PATH
-                        Path where a temporary anki db will be stored (ex
-                        /tmp/anki.db)
+                        Name of the anki profile you want to make indexable (ex: Main)
+  -o OUT_PATH, --output_dir OUT_PATH
+                        Path to the directory where the indexable archive will be found
+  -f {zip,directory}, --format {zip,directory}
+                        Format of the output archive. Default: zip
 ```
 
 ## How do cards look like afterwards?


### PR DESCRIPTION
This is useful for me, as the first thing I do with the archive in my workflow is unzip it (zipping and unzipping both take time).